### PR TITLE
Upgrading workflow to run when main is pushed to

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,9 @@ on:
       - opened
       - synchronize
       - reopened
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
We should do this anyway, but will also mean we end up building our gradle cache to make subsequent builds faster on GitHub actions