### PR TITLE
Updated workflows to handle releases, tidied up workflows and fixed publishing bug

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -28,7 +26,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.5.1
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+name: Pull Request
+on:
+  schedule:
+    - cron: '0 0 * * SAT'
+
+jobs:
+  build:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Calver Release
+        uses: StephaneBour/actions-calver@master
+        id: calver
+        with:
+          date_format: "%Y-%m-%d"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: true
+
+      - name: Build
+        env:
+          VERSION: ${{ steps.calver.outputs.release }}
+        run: |
+          ./gradlew publishMavenPublicationToSonatypeStagingRepository  \
+            -PreleaseVersion="VERSION" \
+            -PossrhUsername="$OSSRH_USERNAME" \
+            -PossrhPassword="$OSSRH_PASSWORD" \
+            -PsigningKey="$GPG_SIGNING_KEY" \
+            -PsigningKeyId="GPG_SIGNING_KEY_ID" \
+            -PsigningPassword="GPG_SIGNING_PASSWORD"

--- a/build-src/src/main/kotlin/dev.mrbergin.conventions-publish.gradle.kts
+++ b/build-src/src/main/kotlin/dev.mrbergin.conventions-publish.gradle.kts
@@ -84,6 +84,6 @@ publishing {
 }
 
 signing {
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword ?: "")
     sign(publishing.publications["maven"])
 }


### PR DESCRIPTION
This change:

* Stops us fetching all git history in build workflow - it's unneeded
* Swaps to using gradle wrapper version rather than specific version in the workflow
* Fixed a publishing bug where null string for password was being passed in (should be empty string for password-less pgp keys
* Created a new release workflow which publishes once a week with calver as the version!