### PR TITLE
Changed release format to %Y.%m.%d

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,13 +13,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
 
       - name: Calver Release
         uses: StephaneBour/actions-calver@master
         id: calver
         with:
-          date_format: "%Y-%m-%d"
+          date_format: "%Y.%m.%d"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
For example instead of 2022-09-22 it will be 2022.09.22

This was done to make it more consistent with semver, which means intellij won't erroneously think version 2022-09-22 comes before version 1.0.0 (which comes up as a warning).