### PR TITLE
Fixed incorrect URL for sonatype staging

### DIFF
--- a/build-src/src/main/kotlin/dev.mrbergin.conventions-publish.gradle.kts
+++ b/build-src/src/main/kotlin/dev.mrbergin.conventions-publish.gradle.kts
@@ -71,7 +71,7 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"))
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
             snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
             username.set(ossrhUsername)
             password.set(ossrhPassword)


### PR DESCRIPTION
Documentation from the publish plugin says to use `https://s01.oss.sonatype.org/service/local/`, so it has been changed to this