### PR TITLE
Fixed a bug where consumers using Java 8 wouldn't work

### DIFF
--- a/build-src/src/main/kotlin/dev.mrbergin.conventions-kotlin.gradle.kts
+++ b/build-src/src/main/kotlin/dev.mrbergin.conventions-kotlin.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.accessors.dm.LibrariesForLibs
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm")
@@ -9,10 +10,20 @@ val libs = the<LibrariesForLibs>()
 
 kotlin {
     jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.kotlin.jvm.build.get()))
     }
 }
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = libs.versions.kotlin.jvm.target.get()
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.release.set(libs.versions.java.release.target.get().toInt())
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
-java = "17"
+kotlin-jvm-build = "17"
+kotlin-jvm-target = "1.8"
+java-release-target = "8"
 kotlin = "1.7.10"
 junit = "5.9.1"
 kotest = "5.4.2"


### PR DESCRIPTION
This change:

* Carries on building using Java 17
* Makes Kotlin target Java 8
* Makes Java release target Java 8

The above hopefully means that the build will carry on using Java 17 for everything, but the resulting Jar will still run on an older JDK.

This at least works on the sample project when running that on Java 8