### PR TITLE
Updated release calver to not have leading zeros

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Calculate Release Version
         run: |
-          NEXT_RELEASE=$(date "+%Y.%m.%d")
+          NEXT_RELEASE=$(date "+%Y.%-m.%-d")
           LAST_RELEASE=$(git tag --sort=v:refname |grep "^20[^\-]*$" |tail -n 1)
           MAJOR_LAST_RELEASE=$(echo "${LAST_RELEASE}" | awk -v l=${#NEXT_RELEASE} '{ string=substr($0, 1, l); print string; }' )
           if [ "${MAJOR_LAST_RELEASE}" = "${NEXT_RELEASE}" ]; then


### PR DESCRIPTION
These bring the calver format more in line with semver which makes ordering releases compatible with how semver releases are ordered