### PR TITLE
Updated version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 [![Build](https://github.com/MrBergin/result4k-kotest-matchers/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/MrBergin/result4k-kotest-matchers/actions/workflows/build.yaml)
+[![MavenCentral](https://img.shields.io/maven-metadata/v.svg?label=maven-central&metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fdev%2Fmrbergin%2Fresult4k-kotest-matchers%2Fmaven-metadata.xml)](https://search.maven.org/search?q=a:result4k-kotest-matchers)
+
 
 # result4k-kotest-matchers
 
-Kotest matchers for the Result4k library
+Kotest matchers for the [Result4k](https://github.com/fork-handles/forkhandles/tree/trunk/result4k) library
 
-Version Matrix
+## Version Matrix
 
 | result4k-kotest-matchers | forkhandles | kotlin | java |
 |:------------------------:|-------------|--------|------|
 |          1.0.0           | 1.14.0.1    | 1.6.10 | 8    |
 |        2022-09-22        | 2.2.0.0     | 1.7.10 | 17   |
-| 2022.09.24.1..2022.09.25 | 2.2.0.0     | 1.7.10 | 8    |
+| 2022.09.24.1..2022.9.26  | 2.2.0.0     | 1.7.10 | 8    |
 
 ## Example Gradle usage:
 
@@ -19,7 +21,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    testImplementation("dev.mrbergin:result4k-kotest-matchers:2022.09.25")
+    testImplementation("dev.mrbergin:result4k-kotest-matchers:2022.9.26")
 }
 ```
 


### PR DESCRIPTION
These changes include:

* Linking to the result4k library itself
* Some formatting (version matrix as heading)
* Updated version matrix and example usage for version 2022.926
* Added a badge!